### PR TITLE
ZOOKEEPER-2964: "Conf" command returns dataDir and dataLogDir opposingly

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/src/java/main/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -185,11 +185,11 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
         pwriter.print("secureClientPort=");
         pwriter.println(getSecureClientPort());
         pwriter.print("dataDir=");
-        pwriter.println(zkDb.snapLog.getDataDir().getAbsolutePath());
+        pwriter.println(zkDb.snapLog.getSnapDir().getAbsolutePath());
         pwriter.print("dataDirSize=");
         pwriter.println(getDataDirSize());
         pwriter.print("dataLogDir=");
-        pwriter.println(zkDb.snapLog.getSnapDir().getAbsolutePath());
+        pwriter.println(zkDb.snapLog.getDataDir().getAbsolutePath());
         pwriter.print("dataLogSize=");
         pwriter.println(getLogDirSize());
         pwriter.print("tickTime=");


### PR DESCRIPTION
See [https://issues.apache.org/jira/browse/ZOOKEEPER-2964](url) for details.

The bug affects versions newer than 3.5. According to Andor Molnar‘s [review](https://issues.apache.org/jira/browse/ZOOKEEPER-2964?focusedCommentId=16330018&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16330018) this patch can be applied to master and branch-3.5 branches.

Thanks all for reviewing this issue.